### PR TITLE
Fix eeprom writes as per srxecore lib

### DIFF
--- a/SmartResponseXEa.cpp
+++ b/SmartResponseXEa.cpp
@@ -934,17 +934,17 @@ int SRXEFlashEraseSector(uint32_t ulAddr, int bWait)
     mydigitalWrite(CS_FLASH, LOW);
     while (rc & 1)
     {
+	    mydigitalWrite(CS_FLASH, LOW);
       SPI_transfer(0x05); // read status register
       rc = SPI_transfer(0);
+	    mydigitalWrite(CS_FLASH, HIGH);
       delay(1);
       timeout++;
       if (timeout >= 120) // took too long, bail out
       {
-        mydigitalWrite(CS_FLASH, HIGH);
         return 0;
       }
     }
-    mydigitalWrite(CS_FLASH, HIGH);
   } // if asked to wait
   return 1;
 } /* SRXEFlashEraseSector() */
@@ -995,17 +995,17 @@ int SRXEFlashWritePage(uint32_t ulAddr, uint8_t *pSrc)
   mydigitalWrite(CS_FLASH, LOW);
   while (rc & 1)
   {
+	  mydigitalWrite(CS_FLASH, LOW);
     SPI_transfer(0x05); // read status register
     rc = SPI_transfer(0);
+	  mydigitalWrite(CS_FLASH, HIGH);
     delay(1);
     timeout++;
     if (timeout >= 20) // took too long, bail out
     {
-      mydigitalWrite(CS_FLASH, HIGH);
       return 0;
     }
   }
-  mydigitalWrite(CS_FLASH, HIGH);
   return 1;
 } /* SRXEFlashWritePage() */
 


### PR DESCRIPTION
I purchased a few units a few months ago and found that basically nothing managed to write the eeprom correctly, not sure if hardware version/build date/aging dependent. Found a fix and submitted it to the srxecore library (https://gitlab.com/bradanlane/srxecore/-/commit/ac742a7b94948b48aad8a9feb8d81c9f8bdad270) . This project however hosts its own platform lib, so it didn't get the fix. People recently receiving units preflashed with this TinyBasic port and who may not have programming hardware are getting units where the MSAVE command doesn't work. 
This is a port of the aforementioned fix, confirmed working on one of my vulnerable? units.